### PR TITLE
Allow quoted words to be recognized as a single term.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ And you will have the value `olá mundo` assigned to the `text` token and the `e
 | Decimal  | A culture-invariant decimal number. |  `-1.123`,`0.1231`,`1.1`, `131.2` |
 | Integer  | A 32 bit number.                    |  `-1`,`0`,`1`, `300` |
 | Long     | A 64 bit number.                    |  `-1`,`0`,`1`, `292908889192986509` |
-| Word     | A text word. It consumes all the input until the next blank space character. You can limit the expected words in the token template initialization. | `Dog`, `cat`, `Banana`    |
+| Word     | A text word. It consumes all the input until the next blank space character. You can limit the expected words in the token template initialization.  Multiple words enclosed within single quotes will be recognized as a single word. | `Dog`, `cat`, `Banana`    |
 | Text     | A text with multiple words. Note that this token type will consume all remaining input, so it must be the last to be parsed in a syntax.              | `This is a sentence`      |
 
 

--- a/src/Takenet.Textc/TextCursor.cs
+++ b/src/Takenet.Textc/TextCursor.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Takenet.Textc
 {
@@ -25,7 +27,10 @@ namespace Takenet.Textc
         public TextCursor(string inputText, IRequestContext context)
         {
             if (inputText == null) throw new ArgumentNullException(nameof(inputText));
-            _tokens = inputText.Split(TOKEN_SEPARATOR);
+            _tokens = Regex.Matches(inputText, @"[\""].+?[\""]|[^ ]+")
+                .Cast<Match>()
+                .Select(m => m.Value.Replace("'",""))
+                .ToArray();
             Context = context;
             Reset();
         }


### PR DESCRIPTION
I downloaded and was playing with textc-csharp and ran into an issue with something I was trying to do because text consumes the remainder of the line you cannot place other tokens afterwards which are dynamic.  If you know the examples of what you want (such as in the calendar example) it works however if you have two dynamic terms separated by a known value it can't seem to be configured.  Using this however, it allows you to recognize two or more words as a single term: 'First Name' is 'Bob Smith'.  

Another example: on the Calendar example the Syntax could be changed so the reminder title was a "word" token type, and the example: "Remind me to 'write some unit tests for the library' today" would work without requiring today to be specified as a known word, allowing today to become dynamic being a given date for example.